### PR TITLE
Change struct initialization for go-codec's api changes

### DIFF
--- a/fluent.go
+++ b/fluent.go
@@ -141,7 +141,8 @@ func NewClient(opts Options) *Client {
 	if !opts.IsFluxion {
 		c.mh = &codec.MsgpackHandle{}
 	} else {
-		c.mh = &codec.MsgpackHandle{RawToString: true, WriteExt: true}
+		c.mh = &codec.MsgpackHandle{WriteExt: true}
+		c.mh.RawToString = true
 	}
 
 	if c.opts.ErrorHandler != nil {


### PR DESCRIPTION
go-codec broke backward compatibility.

```
$ go build
# github.com/yosisa/gofluent
./fluent.go:144:31: cannot use promoted field BasicHandle.DecodeOptions.RawToString in struct literal of type codec.MsgpackHandle
```

This PR fixes that.